### PR TITLE
Use freeipa_domain on all the systems, not just on client

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 #  
 freeipa_replicas: []
+freeipa_domain: "{{ ansible_domain }}"

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -15,7 +15,7 @@
   when: ansible_domain is not defined
 
 - name: Install the client in the realm
-  shell: ipa-client-install --domain={{ freeipa_domain |default(ansible_domain) }} --server={{ freeipa_master }} -p admin  -U -w {{ kerberos_admin_password }}
+  shell: ipa-client-install --domain={{ freeipa_domain }} --server={{ freeipa_master }} -p admin  -U -w {{ kerberos_admin_password }}
   args:
     creates: /etc/ipa/default.conf
   no_log: True

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install the master server
-  shell: ipa-server-install -r {{ ansible_domain | upper }} -n {{ ansible_domain }} -p {{ directory_admin_password }}  -U -a {{ kerberos_admin_password }} --ip-address {{ ansible_default_ipv4.address }}
+  shell: ipa-server-install -r {{ freeipa_domain | upper }} -n {{ freeipa_domain }} -p {{ directory_admin_password }}  -U -a {{ kerberos_admin_password }} --ip-address {{ ansible_default_ipv4.address }}
   args:
     creates: /etc/ipa/default.conf
   no_log: True


### PR DESCRIPTION
While reinstalling the freeipa server of gluster, I was surprised
to see it was using rax.gluster.org. It turn out that it
was installed as "freeipa.gluster.org", and then later got renamed
to freeipa.rax.gluster.org, and so I didn't see that ansible would
auto detect the domain incorrectly.